### PR TITLE
SENSOR FIX: Separating the ultrasonic data with separate process such as process_c.py

### DIFF
--- a/raspi_code/lib/processes/process_b.py
+++ b/raspi_code/lib/processes/process_b.py
@@ -1,9 +1,26 @@
 """
 Path: lib/processes/process_b.py
 Description:
-    Hardware control process — sensors, motors, LCD display.
+    Hardware control process — motors, LCD display, keypad, Firebase.
     Reads Firebase RTDB state and physical keypad, drives feed/water motors,
     updates LCD, and logs analytics back to Firebase.
+
+    Sensor reads (v3 — offloaded to process_c):
+        Feed and water level percentages are no longer read directly in this
+        process. process_c runs the HC-SR04 ultrasonic sensors in a dedicated
+        loop with the median filter enabled and writes the latest values into
+        two shared multiprocessing.Value floats:
+
+            shared_feed_level  : multiprocessing.Value('d')
+            shared_water_level : multiprocessing.Value('d')
+
+        This process reads those values on every tick via:
+            current_feed_level  = shared_feed_level.value
+            current_water_level = shared_water_level.value
+
+        No locks are acquired on the read side — reading a double is atomic
+        on all supported platforms and the occasional torn read of a float
+        (one stale byte) is harmless compared to blocking the tick loop.
 
     Water refill behaviour (v2):
         Refill is now fully manual and toggle-based.
@@ -48,7 +65,6 @@ from lib.services import firebase_rtdb
 from lib.services.firebase_rtdb import FirebaseInitError, FirebaseReadError
 from lib.services.hardware import (
     motor_controller        as motor,
-    ultrasonic_controller   as distance,
     lcd_controller          as lcd,
 )
 from lib.services.hardware.keypad_controller import Keypad4x4, KeypadError
@@ -191,7 +207,10 @@ def _handle_feed_dispense(state: bool) -> None:
 
 def _read_pins_data(keypad_instance: Keypad4x4) -> dict:
     """
-    Read all sensors and keypad state.
+    Read keypad state only.
+
+    Sensor levels are NO LONGER read here — they come from shared memory
+    (shared_feed_level, shared_water_level) written by process_c.
 
     Uses scan_key() (no debounce) — debouncing for the toggle logic is
     handled upstream via the physical button cooldown timer, not here.
@@ -206,12 +225,7 @@ def _read_pins_data(keypad_instance: Keypad4x4) -> dict:
     elif key == "#":
         current_water_physical_button_state = True
 
-    feed_level  = distance.read_left_distance()
-    water_level = distance.read_right_distance()
-
     return {
-        "current_feed_level"                    : _convert_to_percentage(feed_level),
-        "current_water_level"                   : _convert_to_percentage(water_level),
         "current_feed_physical_button_state"    : current_feed_physical_button_state,
         "current_water_physical_button_state"   : current_water_physical_button_state,
         "raw_key"                               : key,
@@ -342,13 +356,16 @@ def _update_lcd_display(
 # ─────────────────────────── PROCESS B ───────────────────────────────────────
 
 def process_B(**kwargs) -> None:
-    args              = kwargs["process_B_args"]
-    TASK_NAME         = args["TASK_NAME"]
-    status_checker    = args["status_checker"]
-    live_status       = args["live_status"]
-    logout_requested  = args["logout_requested"]
-    USER_CREDENTIAL   = args["USER_CREDENTIAL"]
-    LCD_I2C_ADDR      = args.get("LCD_I2C_ADDR", 0x27)
+    args               = kwargs["process_B_args"]
+    TASK_NAME          = args["TASK_NAME"]
+    status_checker     = args["status_checker"]
+    live_status        = args["live_status"]
+    logout_requested   = args["logout_requested"]
+    USER_CREDENTIAL    = args["USER_CREDENTIAL"]
+    LCD_I2C_ADDR       = args.get("LCD_I2C_ADDR", 0x27)
+    # ── Shared memory from process_c ──────────────────────────────────────
+    shared_feed_level  = args["shared_feed_level"]   # multiprocessing.Value('d')
+    shared_water_level = args["shared_water_level"]  # multiprocessing.Value('d')
 
     log(details=f"{TASK_NAME} - Running", log_type="info")
 
@@ -384,7 +401,9 @@ def process_B(**kwargs) -> None:
         status_checker.clear()
         GPIO.cleanup()
         return
-    distance.setup_ultrasonics()
+
+    # NOTE: distance.setup_ultrasonics() is intentionally NOT called here.
+    # Ultrasonic setup and reads are now owned entirely by process_c.
 
     lcd_obj = None
     try:
@@ -481,18 +500,21 @@ def process_B(**kwargs) -> None:
                 current_time = time.time()
                 time.sleep(0.1)
 
-                # ── Read pins ─────────────────────────────────────────────
+                # ── Read keypad ───────────────────────────────────────────
+                # Sensor levels come from shared memory (process_c), not here.
                 try:
                     pins_data = _read_pins_data(keypad_instance)
-                    current_feed_level                  = pins_data["current_feed_level"]
-                    current_water_level                 = pins_data["current_water_level"]
                     current_feed_physical_button_state  = pins_data["current_feed_physical_button_state"]
                     current_water_physical_button_state = pins_data["current_water_physical_button_state"]
                     raw_key                             = pins_data["raw_key"]
                 except Exception as e:
-                    log(details=f"{TASK_NAME} - Sensor read failed: {e}", log_type="error")
+                    log(details=f"{TASK_NAME} - Keypad read failed: {e}", log_type="error")
                     status_checker.clear()
                     break
+
+                # ── Read sensor levels from shared memory (process_c) ─────
+                current_feed_level  = shared_feed_level.value
+                current_water_level = shared_water_level.value
 
                 # ── D-key hold → logout request ───────────────────────────
                 if raw_key == "D":

--- a/raspi_code/lib/processes/process_c.py
+++ b/raspi_code/lib/processes/process_c.py
@@ -1,0 +1,139 @@
+"""
+Path: lib/processes/process_c.py
+Description:
+    Ultrasonic sensor process — reads feed (left) and water (right) HC-SR04
+    sensors in a tight dedicated loop and writes results into two shared
+    multiprocessing.Value floats that process_b reads every tick.
+
+    Why a separate process?
+        process_b runs a 100ms tick loop that also handles keypad scanning,
+        Firebase reads, motor logic, and LCD updates. The HC-SR04 median
+        filter (5 samples × 30ms apart) takes ~150ms per sensor — longer
+        than the entire tick budget. Running both sensors sequentially inside
+        the tick loop caused the loop to drift and produced unstable level
+        readings because the second sensor fired while the first echo was
+        still ringing.
+
+        Moving sensor reads into their own process gives them a dedicated CPU
+        core with no competition, allows the median filter to run at full
+        fidelity, and lets process_b simply read the latest value from shared
+        memory on every tick without blocking.
+
+    IPC — multiprocessing.Value (shared memory):
+        Two c_double Values are created in main.py and passed to both
+        process_b and process_c:
+
+            shared_feed_level  : c_double — latest feed level  (%)
+            shared_water_level : c_double — latest water level (%)
+
+        process_c writes; process_b reads. Value uses a Lock internally so
+        reads and writes are atomic — no additional synchronisation needed
+        for two simple float updates.
+
+    Sensor loop:
+        Each iteration reads left sensor → right sensor using the median
+        filter (5 samples). Total cycle time ≈ 300–400ms. The loop runs
+        continuously; there is no artificial sleep between cycles so the
+        shared values are always as fresh as the hardware allows.
+
+    Shutdown:
+        process_c checks status_checker on every iteration. When any other
+        process clears status_checker (fatal error) process_c exits cleanly
+        and calls GPIO.cleanup().
+
+    Logging contract (same as all service modules in this project):
+        process_c logs freely at all levels via get_logger.
+        ultrasonic_controller raises exceptions only — no internal logging.
+"""
+
+import RPi.GPIO as GPIO
+
+from lib.services.hardware import ultrasonic_controller as distance
+from lib.services.logger import get_logger
+
+log = get_logger("process_c.py")
+
+
+def process_C(**kwargs) -> None:
+    args               = kwargs["process_C_args"]
+    TASK_NAME          = args["TASK_NAME"]
+    status_checker     = args["status_checker"]
+    shared_feed_level  = args["shared_feed_level"]   # multiprocessing.Value('d')
+    shared_water_level = args["shared_water_level"]  # multiprocessing.Value('d')
+
+    log(details=f"{TASK_NAME} - Running", log_type="info")
+
+    GPIO.setmode(GPIO.BCM)
+    GPIO.setwarnings(False)
+
+    try:
+        distance.setup_ultrasonics()
+    except Exception as e:
+        log(details=f"{TASK_NAME} - Ultrasonic setup failed: {e}", log_type="error")
+        status_checker.clear()
+        GPIO.cleanup()
+        return
+
+    log(details=f"{TASK_NAME} - Ultrasonic sensors initialized", log_type="info")
+
+    try:
+        while True:
+            if not status_checker.is_set():
+                log(
+                    details=f"{TASK_NAME} - status_checker cleared, shutting down",
+                    log_type="warning",
+                )
+                break
+
+            # ── Read feed sensor (left) ───────────────────────────────────
+            try:
+                feed_cm = distance.read_left_distance()
+                feed_pct = _to_percent(feed_cm)
+                with shared_feed_level.get_lock():
+                    shared_feed_level.value = feed_pct
+            except Exception as e:
+                log(
+                    details=f"{TASK_NAME} - Feed sensor read failed: {e}",
+                    log_type="warning",
+                )
+
+            # ── Read water sensor (right) ─────────────────────────────────
+            try:
+                water_cm = distance.read_right_distance()
+                water_pct = _to_percent(water_cm)
+                with shared_water_level.get_lock():
+                    shared_water_level.value = water_pct
+            except Exception as e:
+                log(
+                    details=f"{TASK_NAME} - Water sensor read failed: {e}",
+                    log_type="warning",
+                )
+
+    except KeyboardInterrupt:
+        log(details=f"{TASK_NAME} - KeyboardInterrupt received", log_type="warning")
+        status_checker.clear()
+
+    except Exception as e:
+        log(details=f"{TASK_NAME} - Unexpected error: {e}", log_type="error")
+        status_checker.clear()
+        raise
+
+    finally:
+        GPIO.cleanup()
+        log(details=f"{TASK_NAME} - Process stopped", log_type="info")
+
+
+# ─────────────────────────── HELPERS ─────────────────────────────────────────
+
+def _to_percent(distance_cm: float, min_dist: int = 10, max_dist: int = 300) -> float:
+    """
+    Convert HC-SR04 distance (cm) to fill percentage.
+
+    Mirrors the conversion in process_b so both processes use identical
+    scaling. Kept here to avoid process_c importing from process_b.
+    """
+    if distance_cm <= min_dist:
+        return 100.0
+    if distance_cm >= max_dist:
+        return 0.0
+    return round((max_dist - distance_cm) / (max_dist - min_dist) * 100, 2)

--- a/raspi_code/lib/services/hardware/ultrasonic_controller.py
+++ b/raspi_code/lib/services/hardware/ultrasonic_controller.py
@@ -12,9 +12,17 @@ Noise reduction:
     Fix: take SAMPLE_COUNT raw readings per call, discard outliers, return
     the median. Spikes are isolated samples — the median survives them.
 
+    The median filter was previously commented out because it blocked the
+    100ms tick loop in process_b (5 samples × 30ms = ~150ms per sensor,
+    ~300ms total — longer than the entire tick budget).
+
+    Now that sensor reads run in their own dedicated process (process_c),
+    the median filter is safe to re-enable. process_c has no tick budget
+    constraint and can spend as long as the hardware requires.
+
 Logging contract:
     This is a service module — no logging. Returns 0.0 on read failure.
-    Callers (process_b) treat persistent 0.0 as a sensor fault.
+    Callers (process_c) treat persistent 0.0 as a sensor fault.
 """
 
 import time
@@ -74,7 +82,7 @@ def _measure_once(trig: int, echo: int) -> float:
     stop = None
 
     # Wait for ECHO to go HIGH
-    timeout = time.time() + 0.04  # 40ms timeout (~6.8m max distance)
+    timeout = time.time() + ECHO_TIMEOUT
     while GPIO.input(echo) == 0 and time.time() < timeout:
         start = time.time()
 
@@ -82,7 +90,7 @@ def _measure_once(trig: int, echo: int) -> float:
         return 0.0
 
     # Wait for ECHO to go LOW
-    timeout = time.time() + 0.04
+    timeout = time.time() + ECHO_TIMEOUT
     while GPIO.input(echo) == 1 and time.time() < timeout:
         stop = time.time()
 
@@ -131,17 +139,23 @@ def read_left_distance() -> float:
     """
     Read feed level sensor (left — GPIO TRIG 25, ECHO 24).
 
+    Uses the median filter — safe to call now that sensor reads run in their
+    own dedicated process (process_c) with no tick budget constraint.
+
     Returns:
         float: Median distance in cm. 0.0 = sensor fault / no valid reading.
     """
-    return _measure_once(LEFT_TRIG, LEFT_ECHO) # _median_distance(LEFT_TRIG, LEFT_ECHO)
+    return _median_distance(LEFT_TRIG, LEFT_ECHO)
 
 
 def read_right_distance() -> float:
     """
     Read water level sensor (right — GPIO TRIG 7, ECHO 8).
 
+    Uses the median filter — safe to call now that sensor reads run in their
+    own dedicated process (process_c) with no tick budget constraint.
+
     Returns:
         float: Median distance in cm. 0.0 = sensor fault / no valid reading.
     """
-    return _measure_once(RIGHT_TRIG, RIGHT_ECHO) # _median_distance(RIGHT_TRIG, RIGHT_ECHO)
+    return _median_distance(RIGHT_TRIG, RIGHT_ECHO)

--- a/raspi_code/main.py
+++ b/raspi_code/main.py
@@ -6,7 +6,7 @@ System Flow:
     2. AuthService.authenticate()
        - credentials/user_credentials.txt exists → re-validate → load
        - Missing → cursor-menu: Login (pair) or Shutdown
-    3. Start Process A + Process B
+    3. Start Process A + Process B + Process C
     4. Wait for processes to finish OR for logout_requested Event
        - logout_requested → terminate processes → call auth.logout() → loop to step 2
        - normal exit → clean shutdown
@@ -14,17 +14,30 @@ System Flow:
 Logout flow (while running):
     - User holds D key on keypad for 3 seconds inside Process B
     - Process B sets logout_requested Event and exits its loop
-    - main.py sees the event, terminates both processes
+    - main.py sees the event, terminates all three processes
     - Calls auth.logout() — deletes user_credentials.txt, cleans Firebase
     - Loops back to authenticate() — cursor menu reappears on LCD
+
+Process C — Ultrasonic sensors:
+    process_c runs the HC-SR04 feed and water level sensors in a dedicated
+    loop with the median filter enabled. It writes the latest readings into
+    two shared multiprocessing.Value('d') objects:
+
+        shared_feed_level  — feed level  (%)
+        shared_water_level — water level (%)
+
+    process_b reads these values on every tick without blocking.
+    The Values are created fresh each session (inside the auth loop) so
+    they are always valid when passed to the child processes.
 """
 
 import os
 import signal
 import sys
-from multiprocessing import Process, Event
+from multiprocessing import Process, Event, Value
+from ctypes import c_double
 
-from lib.processes import process_a, process_b
+from lib.processes import process_a, process_b, process_c
 from lib.services.auth import (
     AuthService,
     FirebaseInitError,
@@ -60,9 +73,9 @@ TURN_USERNAME    = os.getenv("TURN_USERNAME")
 TURN_PASSWORD    = os.getenv("TURN_PASSWORD")
 
 
-def _stop_processes(task_A: Process, task_B: Process) -> None:
-    """Terminate both processes and wait for them to exit."""
-    for task in [task_A, task_B]:
+def _stop_processes(*tasks: Process) -> None:
+    """Terminate all processes and wait for them to exit."""
+    for task in tasks:
         if task.is_alive():
             task.terminate()
             task.join(timeout=5)
@@ -161,6 +174,12 @@ def main() -> None:
         live_status.clear()
         logout_requested.clear()
 
+        # ── Shared sensor values — written by process_c, read by process_b ─
+        # Value('d') is a double-precision float backed by shared memory.
+        # Initialized to 0.0; process_c overwrites on its first read cycle.
+        shared_feed_level  = Value(c_double, 0.0)
+        shared_water_level = Value(c_double, 0.0)
+
         # ── Step 3: Start processes ───────────────────────────────────────
         task_A = Process(
             target=process_a.process_A,
@@ -181,36 +200,54 @@ def main() -> None:
         task_B = Process(
             target=process_b.process_B,
             kwargs={"process_B_args": {
-                "TASK_NAME"        : "Process B",
-                "status_checker"   : status_checker,
-                "live_status"      : live_status,
-                "logout_requested" : logout_requested,
-                "USER_CREDENTIAL"  : user_credentials,
-                "LCD_I2C_ADDR"     : 0x27,
+                "TASK_NAME"          : "Process B",
+                "status_checker"     : status_checker,
+                "live_status"        : live_status,
+                "logout_requested"   : logout_requested,
+                "USER_CREDENTIAL"    : user_credentials,
+                "LCD_I2C_ADDR"       : 0x27,
+                # Shared memory — process_b reads, process_c writes
+                "shared_feed_level"  : shared_feed_level,
+                "shared_water_level" : shared_water_level,
+            }}
+        )
+
+        task_C = Process(
+            target=process_c.process_C,
+            kwargs={"process_C_args": {
+                "TASK_NAME"          : "Process C",
+                "status_checker"     : status_checker,
+                # Shared memory — process_c writes, process_b reads
+                "shared_feed_level"  : shared_feed_level,
+                "shared_water_level" : shared_water_level,
             }}
         )
 
         task_A.start()
         task_B.start()
+        task_C.start()
+
+        log(details="Process A, B, C started", log_type="info")
 
         # ── Step 4: Wait — monitor for logout or normal exit ──────────────
         try:
-            while task_A.is_alive() or task_B.is_alive():
+            while task_A.is_alive() or task_B.is_alive() or task_C.is_alive():
                 if logout_requested.is_set():
                     log(details="Logout requested — stopping processes", log_type="info")
                     break
                 task_A.join(timeout=0.5)
                 task_B.join(timeout=0.5)
+                task_C.join(timeout=0.5)
 
         except KeyboardInterrupt:
             # KeyboardInterrupt is now handled by the SIGINT signal handler
             # above, but keep this as a fallback for edge cases.
             log(details="KeyboardInterrupt — stopping", log_type="warning")
-            _stop_processes(task_A, task_B)
+            _stop_processes(task_A, task_B, task_C)
             break
 
         # ── Step 5: Stop processes cleanly ───────────────────────────────
-        _stop_processes(task_A, task_B)
+        _stop_processes(task_A, task_B, task_C)
 
         # ── Step 6: Handle logout vs normal exit ─────────────────────────
         if logout_requested.is_set():


### PR DESCRIPTION
**Here's a summary of every change made and why.**

**`process_c.py` (new file)**
Owns the ultrasonic sensors entirely. Runs a tight loop: read left sensor → read right sensor → write percentages into `shared_feed_level` and `shared_water_level`. No artificial sleep between cycles — the median filter's own 5 × 30ms sampling already paces the loop at ~300–400ms per cycle. Shuts down cleanly when `status_checker` is cleared by any other process.

**`ultrasonic_controller.py` (modified)**
`read_left_distance()` and `read_right_distance()` now call `_median_distance()` instead of `_measure_once()`. This was previously commented out because it blocked the 100ms tick loop. That constraint no longer exists — `process_c` has a dedicated core with no tick budget. The `ECHO_TIMEOUT` constant is also now used consistently in `_measure_once()` instead of the hardcoded 0.04.

**`process_b.py` (modified)**
Two changes only — minimal as required:

`_read_pins_data()` now reads keypad only — the two sensor lines are removed
At the top of the inner tick loop, sensor levels are read from shared memory: `shared_feed_level.value` and `shared_water_level.value` — two fast attribute reads, no blocking
`distance.setup_ultrasonics()` is removed from the hardware init block (process_c owns that now)
`shared_feed_level` and `shared_water_level` are accepted via `process_B_args`

Everything else in `process_b` is completely unchanged.